### PR TITLE
initial macro port

### DIFF
--- a/dbt/adapters/sqlserver/connections.py
+++ b/dbt/adapters/sqlserver/connections.py
@@ -141,9 +141,9 @@ class SQLServerConnectionManager(SQLConnectionManager):
 
         with self.exception_handler(sql):
             if abridge_sql_log:
-                logger.debug('On %s: %s....', connection.name, sql[0:512])
+                logger.debug('On {}: {}....', connection.name, sql[0:512])
             else:
-                logger.debug('On %s: %s', connection.name, sql)
+                logger.debug('On {}: {}', connection.name, sql)
             pre = time.time()
 
             cursor = connection.handle.cursor()

--- a/dbt/include/sqlserver/macros/adapters.sql
+++ b/dbt/include/sqlserver/macros/adapters.sql
@@ -85,7 +85,11 @@
   {%- set cci_name = relation.schema ~ '_' ~ relation.identifier ~ '_cci' -%}
   {%- set relation_name = relation.schema ~ '_' ~ relation.identifier -%}
   {%- set full_relation = relation.schema ~ '.' ~ relation.identifier -%}
-  DROP INDEX IF EXISTS {{relation_name}}.{{cci_name}}
+  if object_id ('{{relation_name}}.{{cci_name}}','U') is not null
+      begin
+      drop index {{relation_name}}.{{cci_name}}
+      end
+
   CREATE CLUSTERED COLUMNSTORE INDEX {{cci_name}}
     ON {{full_relation}}
 {% endmacro %}

--- a/dbt/include/sqlserver/macros/adapters.sql
+++ b/dbt/include/sqlserver/macros/adapters.sql
@@ -63,14 +63,12 @@
 {% endmacro %}
 
 
+{# TODO Actually Implement the rename index piece #}
+{# TODO instead of deleting it...  #}
 {% macro sqlserver__rename_relation(from_relation, to_relation) -%}
   {% call statement('rename_relation') -%}
-    EXEC sp_rename '{{ from_relation.schema }}.{{ from_relation.identifier }}', '{{ to_relation.identifier }}'
-    IF EXISTS(
-    SELECT *
-    FROM sys.indexes
-    WHERE name='{{ from_relation.schema }}_{{ from_relation.identifier }}_cci' and object_id = OBJECT_ID('{{ from_relation.schema }}.{{ to_relation.identifier }}'))
-    EXEC sp_rename N'{{ from_relation.schema }}.{{ to_relation.identifier }}.{{ from_relation.schema }}_{{ from_relation.identifier }}_cci', N'{{ from_relation.schema }}_{{ to_relation.identifier }}_cci', N'INDEX'
+  
+    rename object {{ from_relation.schema }}.{{ from_relation.identifier }} to {{ to_relation.identifier }}
   {%- endcall %}
 {% endmacro %}
 

--- a/dbt/include/sqlserver/macros/adapters.sql
+++ b/dbt/include/sqlserver/macros/adapters.sql
@@ -41,12 +41,21 @@
 
 {% macro sqlserver__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    drop {{ relation.type }} if exists {{ relation.schema }}.{{ relation.identifier }}
+    if object_id ('{{ relation.schema }}.{{ relation.identifier }}','U') is not null
+      begin
+      drop {{ relation.type }} {{ relation.schema }}.{{ relation.identifier }}
+      end
   {%- endcall %}
 {% endmacro %}
 
+
+{# if object_id ('source.stg_absence_hours__dbt_tmp','U') is not null drop table source.stg_absence_hours__dbt_tmp; #}
+
 {% macro sqlserver__drop_relation_script(relation) -%}
-    drop {{ relation.type }} if exists {{ relation.schema }}.{{ relation.identifier }}
+  if object_id ('{{ relation.schema }}.{{ relation.identifier }}','U') is not null
+    begin
+    drop {{ relation.type }} {{ relation.schema }}.{{ relation.identifier }}
+    end
 {% endmacro %}
 
 {% macro sqlserver__check_schema_exists(database, schema) -%}

--- a/dbt/include/sqlserver/macros/indexes.sql
+++ b/dbt/include/sqlserver/macros/indexes.sql
@@ -7,15 +7,15 @@
 
 {{ log("Running drop_xml_indexes() macro...") }}
 
-declare @drop_xml_indexes nvarchar(max);
-select @drop_xml_indexes = (
-    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; '
-	from sys.indexes
+declare @drop_xml_indexes nvarchar(max) = (
+  select STRING_AGG(a.command, ' ') from (
+    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; ' as command
+    from sys.indexes
     inner join sys.tables on sys.indexes.object_id = sys.tables.object_id
     where sys.indexes.[name] is not null
       and sys.indexes.type_desc = 'XML'
       and sys.tables.[name] = '{{ this.table }}'
-    for xml path('')
+    ) a
 ); exec sp_executesql @drop_xml_indexes;
 
 {%- endmacro %}
@@ -27,15 +27,15 @@ select @drop_xml_indexes = (
 
 {{ log("Running drop_spatial_indexes() macro...") }}
 
-declare @drop_spatial_indexes nvarchar(max);
-select @drop_spatial_indexes = (
-    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; '
+declare @drop_spatial_indexes nvarchar(max) = (
+  select STRING_AGG(a.command, ' ') from (
+    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; ' as command
     from sys.indexes
     inner join sys.tables on sys.indexes.object_id = sys.tables.object_id
     where sys.indexes.[name] is not null
       and sys.indexes.type_desc = 'Spatial'
       and sys.tables.[name] = '{{ this.table }}'
-    for xml path('')
+    ) a
 ); exec sp_executesql @drop_spatial_indexes;
 
 {%- endmacro %}
@@ -46,13 +46,13 @@ select @drop_spatial_indexes = (
 
 {{ log("Running drop_fk_constraints() macro...") }}
 
-declare @drop_fk_constraints nvarchar(max);
-select @drop_fk_constraints = (
-    select 'IF OBJECT_ID(''' + SCHEMA_NAME(CONVERT(VARCHAR(MAX), sys.foreign_keys.[schema_id])) + '.' + sys.foreign_keys.[name] + ''', ''F'') IS NOT NULL ALTER TABLE [' + SCHEMA_NAME(sys.foreign_keys.[schema_id]) + '].[' + OBJECT_NAME(sys.foreign_keys.[parent_object_id]) + '] DROP CONSTRAINT [' + sys.foreign_keys.[name]+ '];'
+declare @drop_fk_constraints nvarchar(max) = (
+  select STRING_AGG(a.command, ' ') from (
+    select 'IF OBJECT_ID(''' + SCHEMA_NAME(CONVERT(VARCHAR(MAX), sys.foreign_keys.[schema_id])) + '.' + sys.foreign_keys.[name] + ''', ''F'') IS NOT NULL ALTER TABLE [' + SCHEMA_NAME(sys.foreign_keys.[schema_id]) + '].[' + OBJECT_NAME(sys.foreign_keys.[parent_object_id]) + '] DROP CONSTRAINT [' + sys.foreign_keys.[name]+ '];' as command
     from sys.foreign_keys
     inner join sys.tables on sys.foreign_keys.[referenced_object_id] = sys.tables.[object_id]
     where sys.tables.[name] = '{{ this.table }}'
-    for xml path('')
+    ) a
 ); exec sp_executesql @drop_fk_constraints;
 
 {%- endmacro %}
@@ -70,14 +70,14 @@ select @drop_fk_constraints = (
 
 {{ log("Running drop_pk_constraints() macro...") }}
 
-declare @drop_pk_constraints nvarchar(max);
-select @drop_pk_constraints = (
-    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL ALTER TABLE [' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + sys.tables.[name] + '] DROP CONSTRAINT [' + sys.indexes.[name]+ '];'
+declare @drop_pk_constraints nvarchar(max) = (
+  select STRING_AGG(a.command, ' ') from (
+    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL ALTER TABLE [' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + sys.tables.[name] + '] DROP CONSTRAINT [' + sys.indexes.[name]+ '];' as command
     from sys.indexes
     inner join sys.tables on sys.indexes.[object_id] = sys.tables.[object_id]
     where sys.indexes.is_primary_key = 1
       and sys.tables.[name] = '{{ this.table }}'
-    for xml path('')
+    ) a
 ); exec sp_executesql @drop_pk_constraints;
 
 {%- endmacro %}
@@ -91,14 +91,14 @@ select @drop_pk_constraints = (
 
 {{ log("Dropping remaining indexes...") }}
 
-declare @drop_remaining_indexes_last nvarchar(max);
-select @drop_remaining_indexes_last = (
-    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; '
+declare @drop_remaining_indexes_last nvarchar(max) = (
+  select STRING_AGG(a.command, ' ') from (
+    select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; ' as command
     from sys.indexes
     inner join sys.tables on sys.indexes.object_id = sys.tables.object_id
     where sys.indexes.[name] is not null
       and sys.tables.[name] = '{{ this.table }}'
-    for xml path('')
+    ) a
 ); exec sp_executesql @drop_remaining_indexes_last;
 
 {%- endmacro %}


### PR DESCRIPTION
macros ported in this PR:
- `drop_relation`,
- `rename_relation`,
- `create_clustered_columnstore_index` 
- `drop_xml_indexes`
- `drop_fk_constraints`
- `drop_all_indexes_on_table`