### PR TITLE
only reference dbt-adapter-tests now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # dbt-synapse
 
 custom [dbt](https://www.getdbt.com) adapter for [Azure Synapse](https://azure.microsoft.com/en-us/services/synapse-analytics/). Major credit due to @mikaelene and [his `sqlserver` custom adapter](https://github.com/mikaelene/dbt-sqlserver).
-Passing all tests in [dbt-integration-tests](https://github.com/fishtown-analytics/dbt-integration-tests/). 
 
 ## major differences b/w `dbt-synapse` and `dbt-sqlserver`
 - macros use only Azure Synapse `T-SQL`. [Relevant GitHub issue](https://github.com/MicrosoftDocs/azure-docs/issues/55713)


### PR DESCRIPTION
`dbt-integration-tests` is now deprecated in favor of `dbt-adapter-tests`