### PR TITLE
if empty insert nothing rather than 'None'

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ sources:
 ```
 ## Changelog
 
+### v0.18.0.2
+
+- Add CI testing (#19)
+- Remove the external table macros in favor of pulling them directly from `dbt-external-tables`
+- Bundle the "`INSERT` & `UPDATE`" `MERGE` workaround into a transaction that can be rolled back (#23) 
+- Handle nulls in csv file for seeds (#20)
+- Verifed that adapter works with `dbt` version `v0.18.1`
+
 ### v0.18.0.1
 - pull AD auth directly from `dbt-sqlserver` (https://github.com/swanderz/dbt-synapse/pull/13)
 - hotfix for broken `create_view()` macro (https://github.com/swanderz/dbt-synapse/pull/14)

--- a/dbt/include/sqlserver/macros/materializations/seed/seed.sql
+++ b/dbt/include/sqlserver/macros/materializations/seed/seed.sql
@@ -16,7 +16,7 @@
             {% for row in chunk -%}
                 {{'SELECT'+' '}}
                 {%- for column in agate_table.column_names -%}
-                    '{{row[column]}}'
+                    '{{row[column] if row[column]}}'
                     {%- if not loop.last%}, {%- endif -%}
                 {%- endfor -%}
                 {%- if not loop.last-%} {{' '+'UNION ALL'+'\n'}} {%- endif -%}

--- a/dbt/include/sqlserver/macros/materializations/seed/seed.sql
+++ b/dbt/include/sqlserver/macros/materializations/seed/seed.sql
@@ -16,7 +16,7 @@
             {% for row in chunk -%}
                 {{'SELECT'+' '}}
                 {%- for column in agate_table.column_names -%}
-                    '{{row[column] if row[column]}}'
+                    '{{row[column] if row[column] is not None}}'
                     {%- if not loop.last%}, {%- endif -%}
                 {%- endfor -%}
                 {%- if not loop.last-%} {{' '+'UNION ALL'+'\n'}} {%- endif -%}

--- a/dbt/include/sqlserver/macros/materializations/seed/seed.sql
+++ b/dbt/include/sqlserver/macros/materializations/seed/seed.sql
@@ -16,7 +16,7 @@
             {% for row in chunk -%}
                 {{'SELECT'+' '}}
                 {%- for column in agate_table.column_names -%}
-                    '{{row[column] if row[column] is not None}}'
+                    '{{row[column] if row[column]}}'
                     {%- if not loop.last%}, {%- endif -%}
                 {%- endfor -%}
                 {%- if not loop.last-%} {{' '+'UNION ALL'+'\n'}} {%- endif -%}


### PR DESCRIPTION
fix for #20. if there's a an empty value, then don't insert a `None` which is what I assume agate table reader does.
does this work for you, @alittlesliceoftom? We _could_ handle the `NULL` being present in a csv example, but I'd rather not.