### PR TITLE
workaround: tempdb has no info_schema

### DIFF
--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -113,7 +113,6 @@
 {% macro synapse__get_columns_in_relation(relation) -%}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
     select
-        ordinal_position,
         column_name,
         data_type,
         character_maximum_length,

--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -89,29 +89,16 @@
 {% endmacro %}
 
 {% macro synapse__create_table_as(temporary, relation, sql) -%}
+   {# temporary isn't used as the syntax is the same #}
    {%- set index = config.get('index', default="CLUSTERED COLUMNSTORE INDEX") -%}
    {%- set dist = config.get('dist', default="ROUND_ROBIN") -%}
-   {% set tmp_relation = relation.incorporate(
-   path={"identifier": relation.identifier.replace("#", "") ~ '_temp_view'},
-   type='view')-%}
-   {%- set temp_view_sql = sql.replace("'", "''") -%}
-
-   {{ synapse__drop_relation_script(tmp_relation) }}
-
-   {{ synapse__drop_relation_script(relation) }}
-
-   EXEC('create view {{ tmp_relation.schema }}.{{ tmp_relation.identifier }} as
-    {{ temp_view_sql }}
-    ');
 
   CREATE TABLE {{ relation.include(database=False) }}
     WITH(
       DISTRIBUTION = {{dist}},
       {{index}}
       )
-    AS (SELECT * FROM {{ tmp_relation.schema }}.{{ tmp_relation.identifier }})
-
-   {{ synapse__drop_relation_script(tmp_relation) }}
+    AS ({{ sql }})
 
 {% endmacro %}
 

--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -121,7 +121,7 @@
         numeric_scale
     from INFORMATION_SCHEMA.COLUMNS
     where table_name = '{{ relation.identifier }}'
-      and table_schema = '{{ relation.schema }}') cols
+      and table_schema = '{{ relation.schema }}'
   {% endcall %}
   {% set table = load_result('get_columns_in_relation').table %}
   {{ return(sql_convert_columns_in_relation(table)) }}

--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -89,16 +89,29 @@
 {% endmacro %}
 
 {% macro synapse__create_table_as(temporary, relation, sql) -%}
-   {# temporary isn't used as the syntax is the same #}
    {%- set index = config.get('index', default="CLUSTERED COLUMNSTORE INDEX") -%}
    {%- set dist = config.get('dist', default="ROUND_ROBIN") -%}
+   {% set tmp_relation = relation.incorporate(
+   path={"identifier": relation.identifier.replace("#", "") ~ '_temp_view'},
+   type='view')-%}
+   {%- set temp_view_sql = sql.replace("'", "''") -%}
+
+   {{ synapse__drop_relation_script(tmp_relation) }}
+
+   {{ synapse__drop_relation_script(relation) }}
+
+   EXEC('create view {{ tmp_relation.schema }}.{{ tmp_relation.identifier }} as
+    {{ temp_view_sql }}
+    ');
 
   CREATE TABLE {{ relation.include(database=False) }}
     WITH(
       DISTRIBUTION = {{dist}},
       {{index}}
       )
-    AS ({{ sql }})
+    AS (SELECT * FROM {{ tmp_relation.schema }}.{{ tmp_relation.identifier }})
+
+   {{ synapse__drop_relation_script(tmp_relation) }}
 
 {% endmacro %}
 

--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -112,25 +112,16 @@
 
 {% macro synapse__get_columns_in_relation(relation) -%}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
-      SELECT
-          column_name,
-          data_type,
-          character_maximum_length,
-          numeric_precision,
-          numeric_scale
-      FROM
-          (select
-              ordinal_position,
-              column_name,
-              data_type,
-              character_maximum_length,
-              numeric_precision,
-              numeric_scale
-          from INFORMATION_SCHEMA.COLUMNS
-          where table_name = '{{ relation.identifier }}'
-            and table_schema = '{{ relation.schema }}') cols
-
-
+    select
+        ordinal_position,
+        column_name,
+        data_type,
+        character_maximum_length,
+        numeric_precision,
+        numeric_scale
+    from INFORMATION_SCHEMA.COLUMNS
+    where table_name = '{{ relation.identifier }}'
+      and table_schema = '{{ relation.schema }}') cols
   {% endcall %}
   {% set table = load_result('get_columns_in_relation').table %}
   {{ return(sql_convert_columns_in_relation(table)) }}


### PR DESCRIPTION
There is currently no tempdb.information_schema like there is for SQL Server and Azure SQL. This introduces challenges for the macro `get_columns_from_relation()`. Basically `get_columns_from_relation` works fine for normal relations becuase we have the normal `INFORMATION_SCHEMA.COLUMNS`. But when the relation is a temp table nothing is returned.

This breaks the adapter's ability use the snapshot (i.e. SCD type 2) materialization.
implementing what is suggested in in [this Stack Overflow post](https://stackoverflow.com/questions/63800841/get-column-names-of-temp-table-in-azure-synapse-dw), which is:
1. if `get_columns_from_relation() is called and the relation is a temp table (i.e. starts with `#`) then:
2. call `SELECT...INTO` to select one row from from the temp table into the temporary actual table
    ```sql
    SELECT TOP(1) * 
    INTO dbo.temp_table_hack
    FROM #actual_temp_table 
    ```
3. recursively call `get_columns_from_relation()` on this new table
4. drop the non-temp table

more info in #40 