### PR TITLE
override new multi-db support in dbt-sqlserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v.0.19.2
+
+### Under the hood
+- override new functionality in dbt-sqlserver [dbt-sqlserver #126](https://github.com/dbt-msft/dbt-sqlserver/pull/126) that allows for cross-database queries. Azure Synapse does not support this, so `sqlserver__` adapter macros that were previously used by dbt-synapse had to be re-implemented as `synapse__` macros. [#49](https://github.com/dbt-msft/dbt-synapse/pull/49)
+
 ## v.0.19.1
 
 ### Under the hood

--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -29,23 +29,7 @@
 {% endmacro %}
 
 {% macro synapse__drop_schema(relation) -%}
-    {%- set tables_in_schema_query %}
-      SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
-      WHERE TABLE_SCHEMA = '{{ relation.schema }}'
-  {% endset %}
-  {% set tables_to_drop = run_query(tables_in_schema_query).columns[0].values() %}
-  {% for table in tables_to_drop %}
-    {%- set schema_relation = adapter.get_relation(database=relation.database,
-                                               schema=relation.schema,
-                                               identifier=table) -%}
-    {% do drop_relation(schema_relation) %}
-  {%- endfor %}
-
-  {% call statement('drop_schema') -%}
-      IF EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ relation.schema }}')
-      BEGIN
-      EXEC('DROP SCHEMA {{ relation.schema }}')
-      END  {% endcall %}
+  {{ return(sqlserver__drop_schema(relation)) }}
 {% endmacro %}
 
 {# TODO make this function just a wrapper of synapse__drop_relation_script #}

--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -11,12 +11,30 @@
     {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}
 {% endmacro %}
 
-{% macro synapse__list_relations_without_caching(schema_relation) %}
-  {{ return(sqlserver__list_relations_without_caching(schema_relation)) }}
+{% macro sqlserver__list_relations_without_caching(schema_relation) %}
+  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+    select
+      table_catalog as [database],
+      table_name as [name],
+      table_schema as [schema],
+      case when table_type = 'BASE TABLE' then 'table'
+           when table_type = 'VIEW' then 'view'
+           else table_type
+      end as table_type
+
+    from information_schema.tables
+    where table_schema like '{{ schema_relation.schema }}'
+      and table_catalog like '{{ schema_relation.database }}'
+  {% endcall %}
+  {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}
  
-{% macro synapse__list_schemas(database) %}
-  {{ return(sqlserver__list_schemas(database)) }}
+{% macro sqlserver__list_schemas(database) %}
+  {% call statement('list_schemas', fetch_result=True, auto_begin=False) -%}
+    select  name as [schema]
+    from sys.schemas
+  {% endcall %}
+  {{ return(load_result('list_schemas').table) }}
 {% endmacro %}
 
 {% macro synapse__create_schema(relation) -%}
@@ -38,7 +56,16 @@
 {% endmacro %}
 
 {% macro synapse__drop_relation_script(relation) -%}
-  {{ return(sqlserver__drop_relation_script(relation)) }}
+  {% if relation.type == 'view' -%}
+    {% set object_id_type = 'V' %}
+  {% elif relation.type == 'table'%}
+    {% set object_id_type = 'U' %}
+  {%- else -%} invalid target name
+  {% endif %}
+  if object_id ('{{ relation.include(database=False) }}','{{ object_id_type }}') is not null
+    begin
+    drop {{ relation.type }} {{ relation.include(database=False) }}
+    end
 {% endmacro %}
 
 {% macro synapse__check_schema_exists(information_schema, schema) -%}

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "dbt-sqlserver~=0.19.0",
+        "dbt-sqlserver>=0.19.1",
         "agate>=1.6,<1.6.2"
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,4 @@ passenv = DBT_SYNAPSE_DB DBT_SYNAPSE_PORT DBT_SYNAPSE_PWD DBT_SYNAPSE_SERVER DBT
 deps =
     -rrequirements.txt
     -e.
+    git+https://github.com/semcha/dbt-sqlserver


### PR DESCRIPTION
override @semcha's new functionality in dbt-sqlserver ([dbt-sqlserver #126](https://github.com/dbt-msft/dbt-sqlserver/pull/126)) that allows for cross-database queries. Azure Synapse does not support this, so the `sqlserver__` adapter macros that were previously used by dbt-synapse had to be re-implemented as `synapse__` macros.
- `synapse__list_relations_without_caching`
- `synapse__list_schemas`
- `synapse__drop_relation`

two other small changes:
- `synapse__drop_schema` now just disptaches to dbt-sqlserver as it's logic was upstreamed into dbt-sqlserver
- cleaned up redundant logic in `synapse__drop_relation()` and `synapse__drop_relation_script()`