### PR TITLE
Fix dbt-snapshot for tables with non-indexable column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v.0.20.0
+
+### Under the hood
+- Fix a bug where snapshots on tables with non-indexable datatypes would throw the error `"The statement failed. Column 'XXXXX' has a data type that cannot participate in a columnstore index. (35343) (SQLExecDirectW)"`
 ## v.0.19.2
 
 ### Under the hood

--- a/dbt/include/synapse/macros/adapters.sql
+++ b/dbt/include/synapse/macros/adapters.sql
@@ -145,8 +145,15 @@
 
     {% do  drop_relation(tmp_tbl_hack) %}
     {% set sql_create %}
+        CREATE TABLE {{ tmp_tbl_hack }}
+        WITH(
+          -- Always use a round-robin heap, since columns with types like varbinaries
+          -- cannot be part of a clustered column store, which is the default index
+          DISTRIBUTION = ROUND_ROBIN,
+          HEAP
+        )
+        AS
         SELECT TOP(1) * 
-        INTO {{tmp_tbl_hack}}
         FROM {{relation}}
     {% endset %}
     {% call statement() -%} {{ sql_create }} {%- endcall %}


### PR DESCRIPTION
Snapshotting a table with non-indexable data types like varbinary or nvarchar(max) result in the error:
`The statement failed. Column 'XXXXX' has a data type that cannot participate in a columnstore index. (35343) (SQLExecDirectW)`. 

The reason for this is that the current query implicitly uses a clustered columnstore index, since this is the default index.
```sql
SELECT TOP(1) * 
INTO {{tmp_tbl_hack}}
FROM {{relation}}
```

I changed this query to a `CTAS` that always implements a `HEAP` to prevent this problem.