### PR TITLE
ensure pool pauses after run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: tox -e integration-synapse
       - run:
           name: pause Synapse pool/db
-          command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
+          command: az synapse sql pool pause --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
           when: always
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,30 @@ jobs:
           azure-sp-tenant: DBT_AZURE_TENANT
       - run:
           name: resume Synapse pool/db
-          command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
+          command: |
+            state=$(az synapse sql pool show --name $DBT_SYNAPSE_DB --resource-group dbt-msft --workspace-name $DBT_SYNAPSE_SERVER --query "status")
+            if [ "$state" = "Paused" ]; then
+              echo "Resuming pool!"
+              az synapse sql pool resume --name $DBT_SYNAPSE_DB --resource-group dbt-msft --workspace-name $DBT_SYNAPSE_SERVER
+              echo "waiting to be resumed"
+              az synapse sql pool wait --sql-pool-name $DBT_SYNAPSE_DB --resource-group dbt-msft --workspace-name $DBT_SYNAPSE_SERVER --custom "state==Online" 
+              echo "Pool is now resumed!"
+            fi
       - run:
           name: Test
           command: tox -e integration-synapse
       - run:
           name: pause Synapse pool/db
-          command: az synapse sql pool pause --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
+          command: |
+            state=$(az synapse sql pool show --name $DBT_SYNAPSE_DB --resource-group dbt-msft --workspace-name $DBT_SYNAPSE_SERVER --query "status")
+            if [ "$state" = "Online" ]; then
+              echo "Pausing pool!"
+              az synapse sql pool pause --name $DBT_SYNAPSE_DB --resource-group dbt-msft --workspace-name $DBT_SYNAPSE_SERVER
+              echo "waiting until paused"
+              az synapse sql pool wait --sql-pool-name $DBT_SYNAPSE_DB --resource-group dbt-msft --workspace-name $DBT_SYNAPSE_SERVER --custom "state==Paused" 
+              echo "Pool is now paused!"
+            fi
+
           when: always
 
 


### PR DESCRIPTION
the "pause" step used the "resume" command when it shouldn't have.