### PR TITLE
re-implement sqlserver test materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- re-implement sqlserver's test materialization logic because Synapse adapter can't find it today
+- re-implement sqlserver's test materialization logic because Synapse adapter can't find it today [#74](https://github.com/dbt-msft/dbt-synapse/pull/74)
 
 ## v.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v.1.0.1
+
+### Fixes
+
+- re-implement sqlserver's test materialization logic because Synapse adapter can't find it today
+
+## v.1.0.0
+
+Please see the following upstream release notes:
+- [dbt-core v1.0.0](https://github.com/dbt-labs/dbt-core/releases/tag/v1.0.0)
+- [dbt-sqlserver v1.0.0](https://github.com/dbt-msft/dbt-sqlserver/releases/tag/v1.0.0)
+
 ## v.0.21.0rc1
 
 Please see the following upstream release notes:

--- a/dbt/adapters/synapse/__version__.py
+++ b/dbt/adapters/synapse/__version__.py
@@ -1,1 +1,1 @@
-version = '1.0.0'
+version = '1.0.1'

--- a/dbt/include/synapse/macros/materializations/tests/test.sql
+++ b/dbt/include/synapse/macros/materializations/tests/test.sql
@@ -1,0 +1,48 @@
+{%- materialization test, adapter='synapse' -%}
+
+  {% set relations = [] %}
+
+  {% set identifier = model['alias'] %}
+  {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}
+  {% set target_relation = api.Relation.create(
+      identifier=identifier, schema=schema, database=database, type='table') -%} %}
+
+
+  {% if old_relation %}
+    {% do adapter.drop_relation(old_relation) %}
+  {% elif not old_relation %}
+    {% do adapter.create_schema(target_relation) %}
+  {% endif %}
+
+  {% call statement(auto_begin=True) %}
+      {{ create_table_as(False, target_relation, sql) }}
+  {% endcall %}
+
+  {% set main_sql %}
+      select *
+      from {{ target_relation }}
+  {% endset %}
+
+  {{ adapter.commit() }}
+
+
+  {% set limit = config.get('limit') %}
+  {% set fail_calc = config.get('fail_calc') %}
+  {% set warn_if = config.get('warn_if') %}
+  {% set error_if = config.get('error_if') %}
+
+  {% call statement('main', fetch_result=True) -%}
+
+    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}
+
+  {%- endcall %}
+
+  {% if should_store_failures() %}
+    {% do relations.append(target_relation) %}
+  {% elif not should_store_failures() %}
+    {% do adapter.drop_relation(target_relation) %}
+  {% endif %}
+
+  {{ return({'relations': relations}) }}
+
+{%- endmaterialization -%}


### PR DESCRIPTION
for whatever reason, as seen in https://github.com/dbt-msft/tsql-utils/pull/76 and our internal pipelines, dbt-synapse isn't looking for or using [sqlserver's test materialization](https://github.com/dbt-msft/dbt-sqlserver/blob/master/dbt/include/sqlserver/macros/materializations/tests/test.sql). The hacky workaround here is to copy the sqlserver version into the dbt-synapse adapter, then it works!

@jtcohen6, any idea what could be going on here? AFAIK, `sqlserver__` macros should be looked for, but perhaps there's a bug with the materialization dispatch functionality?