### PR TITLE
removed anders logged comment

### DIFF
--- a/dbt/adapters/synapse/__version__.py
+++ b/dbt/adapters/synapse/__version__.py
@@ -1,1 +1,1 @@
-version = '0.21.0'
+version = '0.21.0rc2'

--- a/dbt/include/synapse/macros/materializations/test.sql
+++ b/dbt/include/synapse/macros/materializations/test.sql
@@ -1,7 +1,5 @@
 {%- materialization test, adapter='synapse' -%}
 
-  {{ log("anders are you there??", info=True) }}
-
   {% set relations = [] %}
 
   {% set identifier = model['alias'] %}

--- a/dbt/include/synapse/macros/materializations/test.sql
+++ b/dbt/include/synapse/macros/materializations/test.sql
@@ -1,0 +1,47 @@
+{%- materialization test, adapter='synapse' -%}
+
+  {{ log("anders are you there??", info=True) }}
+
+  {% set relations = [] %}
+
+  {% set identifier = model['alias'] %}
+  {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}
+  {% set target_relation = api.Relation.create(
+      identifier=identifier, schema=schema, database=database, type='table') -%} %}
+
+  {% if old_relation %}
+      {% do adapter.drop_relation(old_relation) %}
+  {% endif %}
+
+  {% call statement(auto_begin=True) %}
+      {{ create_table_as(False, target_relation, sql) }}
+  {% endcall %}
+
+  {% set main_sql %}
+      select *
+      from {{ target_relation }}
+  {% endset %}
+
+  {{ adapter.commit() }}
+
+
+  {% set limit = config.get('limit') %}
+  {% set fail_calc = config.get('fail_calc') %}
+  {% set warn_if = config.get('warn_if') %}
+  {% set error_if = config.get('error_if') %}
+
+  {% call statement('main', fetch_result=True) -%}
+
+    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}
+
+  {%- endcall %}
+
+  {% if should_store_failures() %}
+    {% do relations.append(target_relation) %}
+  {% elif not should_store_failures() %}
+    {% do adapter.drop_relation(target_relation) %}
+  {% endif %}
+  
+  {{ return({'relations': relations}) }}
+
+{%- endmaterialization -%}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import find_namespace_packages
+from setuptools import find_namespace_packages, setup
 import os
 import re
 


### PR DESCRIPTION
Removing @dataders  log from 0.21.0rc2 from #77. 

I downloaded dbt-synapse 0.21.0 from the [release assets](https://github.com/dbt-msft/dbt-synapse/releases/tag/v0.21.0), and couldn't find the name logging file, `test.sql`, there. So I'm assuming #77 is using 0.21.0rc2 instead. Removing name logging either way for good measure. @dataders if you want 0.21.0rc2 to be working for users, instead of just upgrading to 0.21.0 then you might have to republish 0.21.0rc2 to PyPI. 