### PR TITLE
v1.8.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.7.0
+
+* Official release
+
 ## v1.7.0rc1
 
 ## Features
@@ -20,6 +24,10 @@
     - dbt_clone (same target and state)
     - seed
 
+## v1.6.0
+
+* Official release
+
 ## v1.6.0rc1
 
 * Support for [dbt-core 1.6](https://github.com/dbt-labs/dbt-core/releases/tag/v1.6.0)
@@ -39,6 +47,10 @@
   - equals
   - dbt_clone
 
+## v1.5.0
+
+* Official release
+
 ## v.1.5.0rc1
 
 ## Features
@@ -56,6 +68,10 @@
     - constraints
     - hooks
     - simple_copy
+
+## v1.4.1
+
+* Official release
 
 ## v1.4.1rc1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # Changelog
+### v1.8.0rc1
+
+## Features
+
+Supporting dbt-core 1.8.0
+
+## Enhancements
+
+[Decouple imports](https://github.com/dbt-labs/dbt-adapters/discussions/87) to common dbt core and dbt adapter interface packages for future maintainability and extensibility.
+
+* Bump dev requirements
+    - from pytest~=7.4. to pytest~=8.0.1
+    - from twine~=4.0.2 to twine~=5.0.0
+    - from pre-commit~=3.5.0 to pre-commit~=3.6.2
+
+* Inherit [dbt-fabric v1.8.0rc2](https://github.com/microsoft/dbt-fabric/blob/v1.8.0rc2/setup.py) - Bump adapter packages
+    - from pyodbc>=4.0.35,<5.1.0" to pyodbc>=4.0.35,<5.2.0
+
+> From now on, Apple-silicon users don't have to locally build pyodbc, because M1, M2 binaries is included in pyodbc from 5.1.0 onwards!
+
 ## v1.7.0
 
 * Official release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ Supporting dbt-core 1.8.0
     - from pytest~=7.4. to pytest~=8.0.1
     - from twine~=4.0.2 to twine~=5.0.0
     - from pre-commit~=3.5.0 to pre-commit~=3.6.2
+    - specify commit SHA of dbt-core and dbt-adapters in dev_requirements.txt, to fix make dev
 
 * Inherit [dbt-fabric v1.8.0rc2](https://github.com/microsoft/dbt-fabric/blob/v1.8.0rc2/setup.py) - Bump adapter packages
     - from pyodbc>=4.0.35,<5.1.0" to pyodbc>=4.0.35,<5.2.0
 
 > From now on, Apple-silicon users don't have to locally build pyodbc, because M1, M2 binaries is included in pyodbc from 5.1.0 onwards!
+
+## Under the hood
+* Fix failing test tests/functional/adapter/test_query_comment.py::TestMacroArgsQueryComments::test_matches_comment to use correct dbt_version, see [dbt-core](https://github.com/dbt-labs/dbt-core/blob/main/tests/functional/adapter/query_comment/test_query_comment.py)
 
 ## v1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Supporting dbt-core 1.8.0
 > From now on, Apple-silicon users don't have to locally build pyodbc, because M1, M2 binaries is included in pyodbc from 5.1.0 onwards!
 
 ## Under the hood
-* Fix failing test tests/functional/adapter/test_query_comment.py::TestMacroArgsQueryComments::test_matches_comment to use correct dbt_version, see [dbt-core](https://github.com/dbt-labs/dbt-core/blob/main/tests/functional/adapter/query_comment/test_query_comment.py)
+* Fix failing test `tests/functional/adapter/test_query_comment.py::TestMacroArgsQueryComments::test_matches_comment` to use correct dbt_version, see [dbt-core](https://github.com/dbt-labs/dbt-core/blob/main/tests/functional/adapter/query_comment/test_query_comment.py)
 
 ## v1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Supporting dbt-core 1.8.0
     - from pytest~=7.4. to pytest~=8.0.1
     - from twine~=4.0.2 to twine~=5.0.0
     - from pre-commit~=3.5.0 to pre-commit~=3.6.2
-    - specify commit SHA of dbt-core and dbt-adapters in dev_requirements.txt, to fix make dev
+    - specify commit SHA of dbt-core and dbt-adapters in dev_requirements.txt, to fix `make dev`
 
 * Inherit [dbt-fabric v1.8.0rc2](https://github.com/microsoft/dbt-fabric/blob/v1.8.0rc2/setup.py) - Bump adapter packages
     - from pyodbc>=4.0.35,<5.1.0" to pyodbc>=4.0.35,<5.2.0

--- a/dbt/adapters/synapse/__version__.py
+++ b/dbt/adapters/synapse/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0rc1"
+version = "1.7.0"

--- a/dbt/adapters/synapse/__version__.py
+++ b/dbt/adapters/synapse/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0"
+version = "1.8.0rc1"

--- a/dbt/adapters/synapse/synapse_adapter.py
+++ b/dbt/adapters/synapse/synapse_adapter.py
@@ -3,11 +3,11 @@ from typing import Any, Dict, List, Optional
 
 from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.cache import _make_ref_key_dict
+from dbt.adapters.events.types import SchemaCreation
 from dbt.adapters.fabric import FabricAdapter
 from dbt.adapters.sql.impl import CREATE_SCHEMA_MACRO_NAME
-from dbt.contracts.graph.nodes import ColumnLevelConstraint, ConstraintType
-from dbt.events.functions import fire_event
-from dbt.events.types import SchemaCreation
+from dbt_common.contracts.constraints import ColumnLevelConstraint, ConstraintType
+from dbt_common.events.functions import fire_event
 
 from dbt.adapters.synapse.synapse_column import SynapseColumn
 from dbt.adapters.synapse.synapse_connection_manager import SynapseConnectionManager

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,15 @@
-pytest==8.0.0
+# install latest changes in dbt-core
+# TODO: how to automate switching from develop to version branches?
+git+https://github.com/dbt-labs/dbt-core.git@fc431010ef0bd11ee6a502fc6c9e5e3e75c5d72d#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-adapters.git@4c289b150853b94beb67921f2a8dd203abe53cbe
+git+https://github.com/dbt-labs/dbt-adapters.git@4c289b150853b94beb67921f2a8dd203abe53cbe#subdirectory=dbt-tests-adapter
+
+pytest==8.0.1
 twine==5.0.0
 wheel==0.42.0
-pre-commit==3.5.0
+pre-commit==3.5.0;python_version<"3.9"
+pre-commit==3.6.2;python_version>="3.9"
 pytest-dotenv==0.5.2
-dbt-tests-adapter~=1.7.4
 aiohttp==3.8.3
 azure-mgmt-synapse==2.0.0
 flaky==3.7.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ authors_list = [
     "Sam Debruyn",
 ]
 dbt_version = "1.8"
-dbt_fabric_requirement = "dbt-fabric~=1.8.0"
+dbt_fabric_requirement = "dbt-fabric~=1.8.0rc2"
 description = """An Azure Synapse adapter plugin for dbt"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ authors_list = [
     "Anders Swanson",
     "Sam Debruyn",
 ]
-dbt_version = "1.7"
-dbt_fabric_requirement = "dbt-fabric~=1.7.4"
+dbt_version = "1.8"
+dbt_fabric_requirement = "dbt-fabric~=1.8.0"
 description = """An Azure Synapse adapter plugin for dbt"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/tests/functional/adapter/test_dbt_show.py
+++ b/tests/functional/adapter/test_dbt_show.py
@@ -1,5 +1,5 @@
 import pytest
-from dbt.tests.adapter.dbt_show.test_dbt_show import (
+from dbt.tests.adapter.dbt_show.fixtures import (
     models__sample_model,
     models__sql_header,
     seeds__sample_seed,

--- a/tests/functional/adapter/test_query_comment.py
+++ b/tests/functional/adapter/test_query_comment.py
@@ -1,3 +1,5 @@
+import json
+
 from dbt.tests.adapter.query_comment.test_query_comment import (
     BaseEmptyQueryComments,
     BaseMacroArgsQueryComments,
@@ -6,6 +8,7 @@ from dbt.tests.adapter.query_comment.test_query_comment import (
     BaseNullQueryComments,
     BaseQueryComments,
 )
+from dbt.version import __version__ as dbt_version
 
 
 class TestQueryCommentsSynapse(BaseQueryComments):
@@ -17,7 +20,18 @@ class TestMacroQueryCommentsSynapse(BaseMacroQueryComments):
 
 
 class TestMacroArgsQueryCommentsSynapse(BaseMacroArgsQueryComments):
-    pass
+    def test_matches_comment(self, project) -> bool:
+        logs = self.run_get_json()
+        expected_dct = {
+            "app": "dbt++",
+            "dbt_version": dbt_version,
+            "macro_version": "0.1.0",
+            "message": f"blah: {project.adapter.config.target_name}",
+        }
+        expected = r"/* {} */\n".format(json.dumps(expected_dct, sort_keys=True)).replace(
+            '"', r"\""
+        )
+        assert expected in logs
 
 
 class TestMacroInvalidQueryCommentsSynapse(BaseMacroInvalidQueryComments):


### PR DESCRIPTION
## Features

Supporting dbt-core 1.8.0

## Enhancements

[Decouple imports](https://github.com/dbt-labs/dbt-adapters/discussions/87) to common dbt core and dbt adapter interface packages for future maintainability and extensibility.

* Bump dev requirements
    - from pytest~=7.4. to pytest~=8.0.1
    - from twine~=4.0.2 to twine~=5.0.0
    - from pre-commit~=3.5.0 to pre-commit~=3.6.2
    - specify commit SHA of dbt-core and dbt-adapters in dev_requirements.txt, to fix `make dev`

* Inherit [dbt-fabric v1.8.0rc2](https://github.com/microsoft/dbt-fabric/blob/v1.8.0rc2/setup.py) - Bump adapter packages
    - from pyodbc>=4.0.35,<5.1.0" to pyodbc>=4.0.35,<5.2.0

> From now on, Apple-silicon users don't have to locally build pyodbc, because M1, M2 binaries is included in pyodbc from 5.1.0 onwards!

## Under the hood
* Fix failing test tests/functional/adapter/test_query_comment.py::TestMacroArgsQueryComments::test_matches_comment to use correct dbt_version, see [dbt-core](https://github.com/dbt-labs/dbt-core/blob/main/tests/functional/adapter/query_comment/test_query_comment.py)