### PR TITLE
create_view_as - Show contracts warning only when contract_config.enf…

### DIFF
--- a/dbt/include/synapse/macros/materializations/models/view/create_view_as.sql
+++ b/dbt/include/synapse/macros/materializations/models/view/create_view_as.sql
@@ -4,9 +4,9 @@
 
   {% set contract_config = config.get('contract') %}
 
-    {{exceptions.warn("Model contracts cannot be enforced by <adapter>!")}}
 
   {% if contract_config.enforced %}
+      {{ exceptions.warn("Model contracts cannot be enforced by <adapter>!" }}
       {{ get_assert_columns_equivalent(sql) }}
   {%- endif %}
 


### PR DESCRIPTION
The `Model contracts cannot be enforced` warning should only be logged if `contract_config.enforced` is set.

This change mimics the behavour that exists in [create_table_as.sql#L17](https://github.com/microsoft/dbt-synapse/blob/7d414cd122c91d3b45dd4e158afd82152c9695ff/dbt/include/synapse/macros/materializations/models/table/create_table_as.sql#L17) and follows guidance from the v1.5 adapter change notes:  https://github.com/dbt-labs/dbt-core/discussions/7213#discussion-4992837