### PR TITLE
[bug] disable `--limit` on `show` (again)

### DIFF
--- a/dbt/include/synapse/macros/adapters/show.sql
+++ b/dbt/include/synapse/macros/adapters/show.sql
@@ -1,14 +1,3 @@
-{% macro get_show_sql(compiled_code, sql_header, limit) -%}
-  {%- if sql_header -%}
-  {{ sql_header }}
-  {%- endif -%}
-  {%- if limit is not none -%}
-    {%- set warn = "--limit is ignored. Synapse doesn't support the implementation" -%}
-    {{ log(warn, info=True) }}
-  {%- endif -%}
-  {{ compiled_code }}
-  
-{% endmacro %}
 
 {% macro get_limit_subquery_sql(sql, limit) %}
   {{ adapter.dispatch('get_limit_subquery_sql', 'dbt')(sql, limit) }}
@@ -16,8 +5,9 @@
 
 {# Synapse doesnt support ANSI LIMIT clause #}
 {% macro synapse__get_limit_subquery_sql(sql, limit) %}
-    select top {{ limit }} *
-    from (
-        {{ sql }}
-    ) as model_limit_subq
+{%- set warn = "-- limit of " ~ limit ~ " is ignored. Synapse doesn't support the implementation" -%}
+
+{{ warn }}
+{{ sql }}
+
 {% endmacro %}

--- a/tests/functional/adapter/test_dbt_show.py
+++ b/tests/functional/adapter/test_dbt_show.py
@@ -66,5 +66,6 @@ class TestShowSqlHeaderSynapse(BaseShowSqlHeader):
     pass
 
 
-class TestShowLimitSynapse(BaseShowLimit):
-    pass
+# Disabled because dbt-synapse doesn't support the `--limit` flag
+# class TestShowLimitSynapse(BaseShowLimit):
+#     pass


### PR DESCRIPTION
https://github.com/microsoft/dbt-synapse/commit/60d33ea42288e344c86f8462b0273f675cd1bad0 of #201, mistakenly added the `get_show_sql()` macro, and shouldn't have. Accordingly I mistakenly thought with #230 that I editing it would have an effect (spoiler: it didn't).

This PR:
- removes `get_show_sql()`
- modifies `synapse__get_limit_subquery_sql()` directly