### PR TITLE
reduce CI parallelism

### DIFF
--- a/.github/workflows/integration-tests-azure.yml
+++ b/.github/workflows/integration-tests-azure.yml
@@ -13,6 +13,8 @@ jobs:
   integration-tests-azure:
     name: Integration tests on Azure
     strategy:
+      fail-fast: true
+      max-parallel: 1
       matrix:
         python_version: ["3.8", "3.9", "3.10", "3.11"]
         msodbc_version: ["17", "18"]


### PR DESCRIPTION
imho, it is not helpful to run 8 tests at once. This change will make it so they run serially.