### PR TITLE
add --empty flag functionality for synapse

### DIFF
--- a/dbt/adapters/synapse/synapse_relation.py
+++ b/dbt/adapters/synapse/synapse_relation.py
@@ -17,3 +17,11 @@ class SynapseRelation(BaseRelation):
     def get_relation_type(cls) -> Type[SynapseRelationType]:
         return SynapseRelationType
 
+    def render_limited(self) -> str:
+        rendered = self.render()
+        if self.limit is None:
+            return rendered
+        elif self.limit == 0:
+            return f"(select top(0) * from {rendered} where false) _dbt_limit_subq"
+        else:
+            return f"(select top({self.limit}) * from {rendered}) _dbt_limit_subq"


### PR DESCRIPTION
The --empty flag in the base project leads to adding a limit to a query, that doesn't work for synapse. this works for synapse