### PR TITLE
Update test macro to wok with custom `generate_schema_name()`

### DIFF
--- a/dbt/include/synapse/macros/materializations/tests/helpers.sql
+++ b/dbt/include/synapse/macros/materializations/tests/helpers.sql
@@ -1,14 +1,15 @@
 {% macro synapse__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}
+  {% set target_schema = var('synapse_test_schema', generate_schema_name() ) %}
 
   -- Create target schema in synapse db if it does not
-  IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ target.schema }}')
+  IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ target_schema }}')
   BEGIN
-    EXEC('CREATE SCHEMA [{{ target.schema }}]')
+    EXEC('CREATE SCHEMA [{{ target_schema }}]')
   END
 
   {% if main_sql.strip().lower().startswith('with') %}
     {% set testview %}
-      {{ target.schema }}.testview_{{ range(1300, 19000) | random }}
+      {{ target_schema }}.testview_{{ range(1300, 19000) | random }}
     {% endset %}
 
     {% set sql = main_sql.replace("'", "''")%}


### PR DESCRIPTION
This is an example of updated code to fix #259 

This would technically be considered a breaking change so I added a new var called `synapse_test_schema` that people could set to `target.name` if they want to go back to the previous behavior.

We could also make it a non-breaking change and make using `generate_schema_name()` opt-in rather than opt-out but the new logic feels more correct to me instead of the current one.